### PR TITLE
Changed reducer syntax. Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ default export of the `innerself/logger` module:
 
 ```javascript
 import { createStore } from "innerself";
-import with_logger from "innerself/logger";
+import withLogger from "innerself/logger";
 import reducer from "./reducer"
 
 const { attach, connect, dispatch } =
-    createStore(with_logger(reducer));
+    createStore(withLogger(reducer));
 ```

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ export default function ActiveList(tasks) {
 ```
 
 The state of your app lives in a store, which you create by passing the reducer
-function to `create_store`:
+function to `createStore`:
 
 ```javascript
-const { attach, connect, dispatch } = create_store(reducer);
+const { attach, connect, dispatch } = createStore(reducer);
 window.dispatch = dispatch;
 export { attach, connect };
 ```
@@ -162,7 +162,7 @@ If you need side-effects, you have three choices:
 The `dispatch` function will also re-render the entire top-level component.  In
 order to be able to do so, it needs to know where in the DOM to put the
 `innerHTML` the top-level component generated.  This is what `attach` returned
-by `create_store` is for:
+by `createStore` is for:
 
 ```javascript
 import { attach } from "./store";
@@ -171,7 +171,7 @@ import App from "./App";
 attach(App, document.querySelector("#root"));
 ```
 
-`create_store` also returns a `connect` function.  Use it to avoid passing data
+`createStore` also returns a `connect` function.  Use it to avoid passing data
 from top-level components down to its children where it makes sense.  In the
 first snippet above, `ActiveList` receives a `tasks` argument which must be
 passed by the top-level component.
@@ -235,10 +235,10 @@ changes to the console.  To use it, simply decorate your reducer with the
 default export of the `innerself/logger` module:
 
 ```javascript
-import { create_store } from "innerself";
+import { createStore } from "innerself";
 import with_logger from "innerself/logger";
 import reducer from "./reducer"
 
 const { attach, connect, dispatch } =
-    create_store(with_logger(reducer));
+    createStore(with_logger(reducer));
 ```

--- a/example01/store.js
+++ b/example01/store.js
@@ -1,10 +1,10 @@
-import { create_store } from "../index";
+import {createStore} from "../index";
 import with_logger from "../logger";
 import reducer from "./reducer"
 
 
 const { attach, connect, dispatch } =
-    create_store(with_logger(reducer));
+    createStore(with_logger(reducer));
 
 window.dispatch = dispatch;
 

--- a/example01/store.js
+++ b/example01/store.js
@@ -1,10 +1,10 @@
 import {createStore} from "../index";
-import with_logger from "../logger";
+import withLogger from "../logger";
 import reducer from "./reducer"
 
 
 const { attach, connect, dispatch } =
-    createStore(with_logger(reducer));
+    createStore(withLogger(reducer));
 
 window.dispatch = dispatch;
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ export default function html([first, ...strings], ...values) {
     ).join("");
 }
 
-export function create_store(reducer) {
+export function createStore(reducer) {
     let state = reducer();
     const roots = new Map();
     const prevs = new Map();


### PR DESCRIPTION
I changed the syntax of the `create_store` method to `createStore`, as well as updated the README. I did this to better match the current spec of Redux. Update: Also updated `with_logger` to `withLogger`.